### PR TITLE
Updated to scrape the top 25 articles about Israel/Palestine

### DIFF
--- a/nytscrape.py
+++ b/nytscrape.py
@@ -1,6 +1,4 @@
 from pynytimes import NYTAPI
-
-# Import datetime function from datetime library which allows us to create a datetime object
 from datetime import datetime
 
 api_key = "XXXXXXXXXX" # make sure to X this out before committing code
@@ -12,28 +10,31 @@ begin = datetime(2023, 1, 1)
 
 end = datetime(2024, 1, 31)
 
-#Create dictionary containing dates data
-
+# Set the beginning and end dates for the search.
 date_dict = {"begin":begin, "end":end}
 
 nyt = NYTAPI(api_key, parse_dates=True)
 
-# Grab the first data item in top_stories and view it
-top_stories = nyt.top_stories()
-
-top_story = top_stories[0]
-
-print("The top story is: ", top_story['title'])
-
-# Retrieve the most viewed articles for today.
+file = open('readdata.txt', 'w')
 
 articles = nyt.article_search(query = "Israel Palestine", 
-                              results = 10,
+                              results = 25,
                               dates = date_dict)
 
-# Assign the data in the first item of articles to a variable
-article = articles[0].copy()
+for article in articles:
+    weburl = article["web_url"]
+    abstract = article["abstract"]
 
-print(article["web_url"])
-print(article["abstract"])
-print(article["multimedia"])
+    file.write(weburl + "\n")
+    file.write(abstract + "\n")
+    
+    multimedia = article["multimedia"]
+    for m in multimedia:
+        mediatype = m["type"]
+        caption = m["caption"]
+        url = "https://www.nytimes.com/" + m["url"]
+
+        if mediatype == "image" and caption != None:
+            file.write(url + "\n")
+            file.write(caption + "\n")
+        file.write("\n")

--- a/readdata.txt
+++ b/readdata.txt
@@ -1,0 +1,60 @@
+https://www.nytimes.com/2023/11/04/opinion/sunday/israel-palestine-speech-debate.html
+Why both sides feel victimized by the campus debate over the war in Gaza.
+https://www.nytimes.com/2024/01/19/opinion/israel-war-netanyahu.html
+Israel has been at war with Hamas for over 100 days and still has over 100 hostages to recover, but Netanyahu’s No. 1 focus is Netanyahu.
+https://www.nytimes.com/2023/12/19/opinion/peace-gaza-israel-palestinians.html
+Three experts tell us how.
+https://www.nytimes.com/2023/12/17/us/campus-crackdowns-have-chilling-effect-on-pro-palestinian-speech.html
+Universities are under tremendous pressure to stamp out antisemitism, but some say that is causing fear and curbing free expression.
+https://www.nytimes.com/interactive/2023/12/12/opinion/gaza-israel-palestinians-plans.html
+Ten visions of postwar scenarios for Gaza from politicians, academics, activists and analysts.
+https://www.nytimes.com/2023/12/05/opinion/ezra-klein-podcast-tareq-baconi.html
+Tareq Baconi traces the history of Hamas and how its political goals have evolved.
+https://www.nytimes.com/2023/11/24/world/middleeast/palestinian-authority-gaza-war.html
+Considered authoritarian and corrupt, the Palestinian Authority is still Washington’s choice to run the enclave. But many believe it can be credible now only if it includes Hamas.
+https://www.nytimes.com/2023/11/21/podcasts/transcript-ezra-klein-interviews-aaron-miller.html
+The Nov. 21, 2023, episode of “The Ezra Klein Show.”
+https://www.nytimes.com/interactive/2023/11/20/magazine/israel-gaza-oslo-accords.html
+Thirty years ago, a negotiated settlement of the Israeli-Palestinian conflict seemed achievable. The story of how it fell apart reveals why the fight remains so intractable today.
+https://www.nytimes.com/2023/11/17/us/students-justice-palestine-campus-protests.html
+Students for Justice in Palestine, which was founded at Berkeley, has fueled activism, and, critics say, intimidation and antisemitism.
+https://www.nytimes.com/2023/11/16/us/palestine-student-protests-aclu-florida-lawsuit.html
+Florida education officials moved to ban chapters of Students for Justice in Palestine, but critics say it’s a clear cut violation of the First Amendment.
+https://www.nytimes.com/2023/11/15/nyregion/columbia-university-ban-student-groups-israel-hamas-war.html
+Students rallied after the university barred two groups from holding campus events until the end of the semester, and faculty members walked out in protest.
+https://www.nytimes.com/2023/11/02/opinion/columnists/campus-speech-culture-war.html
+College can be contentious, but it must be safe and free.
+https://www.nytimes.com/2023/10/25/us/politics/trump-republicans-colleges-israel-hamas.html
+The G.O.P. field, including former President Trump, has been wading into the emotional debate among students playing out over the deadly war between Hamas and Israel.
+https://www.nytimes.com/2023/10/24/nyregion/columbia-giving-day-israel-hamas-war.html
+Columbia has said it should be a space for “moral and intellectual conversations” about the Israel-Hamas war, but as those conversations harden, the choice may affect its finances.
+https://www.nytimes.com/2023/10/20/nyregion/college-protest-israel-palestine.html
+Past student demonstrations sought to challenge the power structure. Now students also want validation.
+https://www.nytimes.com/2023/10/12/opinion/columnists/israel-gaza-massacre-left.html
+Celebration of Hamas is both disgusting and self-defeating.
+https://www.nytimes.com/2023/10/08/world/middleeast/timeline-gaza-israel-attacks-hamas.html
+The first air raid sirens went off at sunrise as Hamas launched an attack by land, sea and air. Israel declared a state of war and has destroyed buildings in Gaza.
+https://www.nytimes.com/2023/12/29/opinion/letters/israel-tough-love.html
+Readers react to a column by Thomas L. Friedman and a news story. Also: Dangerous child labor; windowless bedrooms; healing power of knitting.
+https://www.nytimes.com/2023/11/29/opinion/donald-trump-autocrat.html
+Readers worry about Donald Trump’s plans if elected — or not elected. Also: Pro-Palestinian students; Mideast myths; standards for prosecutors; neoliberalism today.
+https://www.nytimes.com/video/world/europe/100000009260715/genocide-hearing-protests.html
+Protesters for Israel and Palestine demonstrated outside the genocide hearing at the International Court of Justice.
+https://www.nytimes.com/2023/10/12/opinion/israel-hamas-president-biden.html
+As the conflict between Israel and Hamas unfolds, the columnist Thomas Friedman shares his perspective on the evolving situation and what he’s watching for.
+https://www.nytimes.com/2023/10/01/books/review/a-day-in-the-life-of-abed-salama-nathan-thrall.html
+In “A Day in the Life of Abed Salama,” Nathan Thrall untangles the political and personal story of a bus crash on the outskirts of Jerusalem.
+https://www.nytimes.com/2023/10/10/world/middleeast/peace-activists-killed-israel.html
+Some of those caught up in the attack by Palestinian fighters lived in residential collectives whose members tend to support peace initiatives and Palestinian rights.
+https://www.nytimes.com/2023/04/06/movies/what-if-ehud-barak-on-war-and-peace-review.html
+Former Israeli Prime Minister Ehud Barak discusses his career in power in this lifeless, often confusing documentary.
+https://www.nytimes.com/2023/10/12/us/politics/desantis-israel-gaza.html
+On the campaign trail in New Hampshire, a prospective voter asked the Florida governor, who has issued statements of staunch support for Israel, about civilian casualties in Gaza.
+https://www.nytimes.com/2024/01/18/world/middleeast/netanyahu-palestinian-state-israel-gaza-war.html
+The Biden administration and the Israeli government diverge sharply over how Gaza should be governed when the war ends.
+https://www.nytimes.com/2023/10/18/world/middleeast/israel-hamas-gaza-un-security-council.html
+The American ambassador said the U.S. couldn’t support a measure that didn’t mention Israel’s right to self-defense.
+https://www.nytimes.com/2023/10/14/world/europe/israeli-palestine-arabs-gaza-tensions.html
+Israeli Arabs, some 18 percent of Israel’s population, speak of heightened tensions with their neighbors, when they are willing to speak at all.
+https://www.nytimes.com/2023/05/01/technology/israel-palestine-facial-recognition.html
+The Israeli government is using computer vision to monitor Palestinian travel across checkpoints, according to the report.


### PR DESCRIPTION
Top 25 articles should saved in a file. Each captioned image is listed under the corresponding article.